### PR TITLE
feat: Introduce email provider abstraction layer

### DIFF
--- a/apps/web/app/api/v1/group/[groupId]/emails/route.ts
+++ b/apps/web/app/api/v1/group/[groupId]/emails/route.ts
@@ -5,12 +5,12 @@ import {
   type GroupEmailsResult,
 } from "@/app/api/v1/group/[groupId]/emails/validation";
 import { withError } from "@/utils/middleware";
-import { validateApiKeyAndGetGmailClient } from "@/utils/api-auth";
+import { validateApiKeyAndGetEmailProvider } from "@/utils/api-auth";
 import { getEmailAccountId } from "@/app/api/v1/helpers";
 
 export const GET = withError(async (request, { params }) => {
-  const { gmail, userId, accountId } =
-    await validateApiKeyAndGetGmailClient(request);
+  const { emailProvider, userId, accountId } =
+    await validateApiKeyAndGetEmailProvider(request);
 
   const { groupId } = await params;
   if (!groupId)
@@ -46,7 +46,7 @@ export const GET = withError(async (request, { params }) => {
   const { messages, nextPageToken } = await getGroupEmails({
     groupId,
     emailAccountId,
-    gmail,
+    emailProvider,
     from: from ? new Date(from) : undefined,
     to: to ? new Date(to) : undefined,
     pageToken,

--- a/apps/web/utils/email-provider/gmail.ts
+++ b/apps/web/utils/email-provider/gmail.ts
@@ -1,0 +1,155 @@
+import type {
+  Email,
+  EmailProvider,
+  Thread,
+} from "@/utils/email-provider/types";
+import {
+  getAccessTokenFromClient,
+  getGmailClientWithRefresh,
+} from "@/utils/gmail/client";
+import {
+  getMessages as getGmailMessages,
+  getMessagesBatch,
+} from "@/utils/gmail/message";
+import {
+  getThreadsWithNextPageToken,
+  getThreadsBatch,
+} from "@/utils/gmail/thread";
+import { getMessage as getGmailMessage } from "@/utils/gmail/message";
+import { getThread as getGmailThread } from "@/utils/gmail/thread";
+import { parseMessage } from "@/utils/mail";
+import type {
+  MessageWithPayload,
+  ParsedMessage,
+  ThreadWithPayloadMessages,
+} from "@/utils/types";
+import type { gmail_v1 } from "@googleapis/gmail";
+import { isDefined } from "@/utils/types";
+
+export class GmailProvider implements EmailProvider {
+  private gmail: gmail_v1.Gmail;
+
+  private constructor(gmail: gmail_v1.Gmail) {
+    this.gmail = gmail;
+  }
+
+  static async create(
+    emailAccountId: string,
+    accessToken: string,
+    refreshToken: string,
+    expiresAt: number,
+  ): Promise<GmailProvider> {
+    const gmail = await getGmailClientWithRefresh({
+      emailAccountId,
+      accessToken,
+      refreshToken,
+      expiresAt,
+    });
+    return new GmailProvider(gmail);
+  }
+
+  async getThreads(options: {
+    query?: string;
+    labelIds?: string[];
+    maxResults?: number;
+    pageToken?: string;
+  }): Promise<{
+    threads: Thread[];
+    nextPageToken?: string;
+  }> {
+    const { threads: gmailThreads, nextPageToken } =
+      await getThreadsWithNextPageToken({
+        gmail: this.gmail,
+        q: options.query,
+        labelIds: options.labelIds,
+        maxResults: options.maxResults,
+        pageToken: options.pageToken,
+      });
+
+    if (!gmailThreads || gmailThreads.length === 0) {
+      return { threads: [], nextPageToken: nextPageToken || undefined };
+    }
+
+    const threadIds = gmailThreads.map((t) => t.id).filter(isDefined);
+    const accessToken = getAccessTokenFromClient(this.gmail);
+    const threadsWithPayload = await getThreadsBatch(threadIds, accessToken);
+
+    return {
+      threads: threadsWithPayload.map(this.transformThread),
+      nextPageToken: nextPageToken || undefined,
+    };
+  }
+
+  async getThread(threadId: string): Promise<Thread | null> {
+    const thread = await getGmailThread(threadId, this.gmail);
+    if (!thread) return null;
+
+    return this.transformThread(thread);
+  }
+
+  async getMessages(options: {
+    query?: string;
+    maxResults?: number;
+    pageToken?: string;
+    labelIds?: string[];
+  }): Promise<{
+    messages: Email[];
+    nextPageToken?: string;
+  }> {
+    const { messages: gmailMessages, nextPageToken } = await getGmailMessages(
+      this.gmail,
+      options,
+    );
+
+    if (!gmailMessages || gmailMessages.length === 0) {
+      return { messages: [], nextPageToken: nextPageToken || undefined };
+    }
+
+    const messageIds = gmailMessages.map((m) => m.id).filter(isDefined);
+    const accessToken = getAccessTokenFromClient(this.gmail);
+    const messagesWithPayload = await getMessagesBatch({
+      messageIds,
+      accessToken,
+    });
+
+    return {
+      messages: messagesWithPayload.map(this.transformMessage),
+      nextPageToken: nextPageToken || undefined,
+    };
+  }
+
+  async getMessage(messageId: string): Promise<Email | null> {
+    const message = await getGmailMessage(messageId, this.gmail);
+    if (!message) return null;
+
+    return this.transformMessage(message as any);
+  }
+
+  private transformMessage(message: MessageWithPayload | ParsedMessage): Email {
+    const parsedMessage =
+      "headers" in message ? message : parseMessage(message);
+
+    return {
+      id: parsedMessage.id,
+      threadId: parsedMessage.threadId,
+      snippet: parsedMessage.snippet,
+      historyId: parsedMessage.historyId,
+      labelIds: parsedMessage.labelIds,
+      payload: {
+        headers: parsedMessage.headers,
+        parts: parsedMessage.parts as any,
+      },
+    };
+  }
+
+  private transformThread(thread: ThreadWithPayloadMessages): Thread {
+    return {
+      id: thread.id!,
+      historyId: thread.historyId!,
+      messages: thread.messages!.map((m) =>
+        this.transformMessage(m as MessageWithPayload),
+      ),
+      snippet: thread.snippet!,
+    };
+  }
+}

--- a/apps/web/utils/email-provider/types.ts
+++ b/apps/web/utils/email-provider/types.ts
@@ -1,0 +1,64 @@
+export interface EmailProvider {
+  getThreads(options: {
+    query?: string;
+    labelIds?: string[];
+    maxResults?: number;
+    pageToken?: string;
+  }): Promise<{
+    threads: Thread[];
+    nextPageToken?: string;
+  }>;
+
+  getThread(threadId: string): Promise<Thread | null>;
+
+  getMessages(options: {
+    query?: string;
+    maxResults?: number;
+    pageToken?: string;
+    labelIds?: string[];
+  }): Promise<{
+    messages: Email[];
+    nextPageToken?: string;
+  }>;
+
+  getMessage(messageId: string): Promise<Email | null>;
+}
+
+export interface Thread {
+  id: string;
+  historyId: string;
+  messages: Email[];
+  snippet: string;
+}
+
+export interface Email {
+  id: string;
+  threadId: string;
+  snippet: string;
+  historyId: string;
+  labelIds: string[];
+  payload: EmailPayload;
+}
+
+export interface EmailPayload {
+  headers: { name: string; value: string }[];
+  parts: EmailPart[];
+}
+
+export interface EmailPart {
+  partId: string;
+  mimeType: string;
+  filename: string;
+  headers: { name: string; value: string }[];
+  body: {
+    size: number;
+    data?: string;
+    attachmentId?: string;
+  };
+}
+
+export interface Attachment {
+  attachmentId: string;
+  filename: string;
+  size: number;
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.1.2",
     "@turbo/gen": "2.5.4",
+    "dotenv": "16.5.0",
     "husky": "9.1.7",
     "lint-staged": "15.5.1",
     "prettier": "3.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       '@turbo/gen':
         specifier: 2.5.4
         version: 2.5.4(@swc/core@1.6.5(@swc/helpers@0.5.15))(@types/node@22.15.29)(typescript@5.8.3)
+      dotenv:
+        specifier: 16.5.0
+        version: 16.5.0
       husky:
         specifier: 9.1.7
         version: 9.1.7


### PR DESCRIPTION
This commit introduces an abstraction layer for email providers, making it possible to support other email services like IMAP and POP3 in the future.

The key changes are:
- A new `EmailProvider` interface that defines a common set of methods for interacting with email services.
- A `GmailProvider` class that implements the `EmailProvider` interface and encapsulates all the Gmail-specific logic.
- Refactoring of the application to use the `EmailProvider` interface instead of the Gmail API directly.

All existing tests have been updated to use the new abstraction layer, and new tests have been added to ensure that the `GmailProvider` is working correctly.